### PR TITLE
Update panflute dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
           "jupyter_client>=5.3.4,<6"
         , "pampy>=0.3.0,<0.4"
-        , "panflute==1.11.2"
+        , "panflute==2.3.0"
         , "ansi2html"
     ],
     tests_require=test_deps,


### PR DESCRIPTION
Fix #13

Using the latest `panflute` version, assuming the user has latest `pandoc` version.

Modification untested locally. Just upgraded as @ngirard suggested. Do we need to add integration tests in the CI workflow? It would install the pip package from the code and run pandoc with the filter on a whole document (or several ones).